### PR TITLE
If ProgramCounter reaches the end of memory, loop.

### DIFF
--- a/cpu.js
+++ b/cpu.js
@@ -126,7 +126,7 @@ function tick(){
 		}
 		memory[0]+=3;//instruction pointer++
 		if(memory[0]>255)
-			memory[0]=0;
+			memory[0]=memory[0]-255;
 	}
 	for(k=0;k<6;k++){
 		etfs[k].value = memory[offset+k];


### PR DESCRIPTION
Currently, if the Program Counter is going to breach 11111111 then it's set to 00000000 - which makes it impossible to ever set it back to the first instruction (00000001).  This fixes it so that it loops correctly.
